### PR TITLE
상태업데이트 에러 해결 및 디자인 인풋에 포커스 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ function App() {
 
         setMembers(deleteMembers)
         localStorage.setItem('members',JSON.stringify(deleteMembers))
+        console.log(members)
   }
 
   const updateMember = (updatedMember:memberType) => {
@@ -51,8 +52,8 @@ function App() {
   return (
     <Container>
       <Header addMember={addMember}/>
-      {members.map((member,index)=>
-        <Member key={index}
+      {members.map((member)=>
+        <Member key={member.name}
         member={member}
         updateMember={updateMember}
         deleteButton={deleteButton}

--- a/src/components/Add.tsx
+++ b/src/components/Add.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import styled from "styled-components"
 import { AddPropsType } from "../types/type"
 import { Close, FormInInput } from "../styled/styled"
@@ -19,18 +19,29 @@ const Container = styled.div`
     z-index: 3;
 `
 
-export default function Add ({addMember,toggleAdd}:AddPropsType){
+export default function Add ({addMember,toggleAdd,add}:AddPropsType){
     const [member,setMember] = useState<string>('')
+
+    const inputRef = useRef<HTMLInputElement | null>(null)
+
+    useEffect(()=>{
+        if(add && inputRef.current){
+            inputRef.current.focus();
+        }
+    },[add])
+    // add의 상태가 변경될 때 input에게 포커스가 갈 수 있게
 
     const handelSubmit = (e:React.FormEvent) => {
         e.preventDefault()
         addMember(member,e)
         toggleAdd()
     }
+
     return(
         <Container>
             <FormInInput onSubmit={handelSubmit} action="#">
             <input
+            ref={inputRef}
                   type="text"
                   placeholder="모임원 이름을 입력하세요."
                   value={member}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,23 +1,47 @@
 import { useState } from "react"
 import Add from "./Add"
+import styled from "styled-components"
 
 type HeaderPropsType={
     addMember: (member:string,e:React.FormEvent)=>void
 }
 
+const Container = styled.div`
+    header{
+        margin-top: 15px;
+        margin-bottom: 15px;
+    }
+    button{
+        width: 100px;
+        height: 50px;
+        border-radius: 15px;
+        background-color: #2274A5;
+        color: #fff;
+        border: none;
+        font-weight: bold;
+        font-size:0.9rem;
+        margin-top: 15px;
+        margin-bottom: 15px;
+        cursor: pointer;
+    }
+`
+
 export default function Header ({addMember}:HeaderPropsType) {
 
-    const [add,setAdd] = useState<Boolean>(false)
+    const [add,setAdd] = useState<boolean>(false)
 
     const toggleAdd = () =>{
         setAdd(!add)
     }
     return(
-        <div>
+        <Container>
             <header>모임원 관리</header>
             <button onClick={toggleAdd}>모임원 추가</button>
 
-            {add === true ? <Add toggleAdd={toggleAdd} addMember={addMember}/> : null}
-        </div>
+            {add === true ? <Add
+             toggleAdd={toggleAdd}
+              addMember={addMember}
+              add={add}/> : null}
+        </Container>
     )
 }

--- a/src/components/Member.tsx
+++ b/src/components/Member.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import styled from "styled-components"
-import { MemberPropsType, memberType } from "../types/type"
+import { MemberPropsType } from "../types/type"
 import Cause from "./Cause"
 import MemberBox from "./MemberBox"
 import { Delete } from "./Delete"
@@ -14,7 +14,7 @@ const Container = styled.div`
 const GridContainer = styled.div`
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;
-    border: 1px solid black;
+    border: 1px solid #632B30;
     margin-bottom: 15px;
     border-radius: 15px;
 `

--- a/src/components/MemberBox.tsx
+++ b/src/components/MemberBox.tsx
@@ -2,25 +2,25 @@ import styled, { css } from "styled-components"
 import { MemberBoxPropsType } from "../types/type"
 
 const Container = styled.div`
-    border-left: 1px solid black;
+    border-left: 1px solid #632B30;
     position: relative;
 `
 
 
-const Button = styled.button<{isWarning?: boolean}>`
+const Button = styled.button<{$isWarning?: boolean}>`
     width: 50%;
-    background-color: beige;
+    background-color: #E7EB90;
     border: none;
-    border-top: 1px solid black;
+    border-top: 1px solid #632B30;
     cursor: pointer;
     @media screen and (max-width:800px) {
         font-size:12px
     }
     &:last-child{
-        border-left: 1px solid black;
+        border-left: 1px solid #632B30;
     }
     ${(props)=>
-        props.isWarning && css `
+        props.$isWarning && css `
             border-bottom-right-radius: 15px
         `
     }
@@ -42,13 +42,13 @@ export default function MemberBox({
 
     return(
         <Container>
-            
+
                 {isWarning ? <WarningP onClick={toggleCause}>{memberOption}</WarningP> : <p>{memberOption}</p>}
-            
+
                     <p>{count}</p>
                     <div>
                     <Button onClick={()=>countUp(memberOption)}>위</Button>
-                    <Button isWarning={isWarning} onClick={()=>countDown(memberOption)}>아래</Button>
+                    <Button $isWarning={isWarning} onClick={()=>countDown(memberOption)}>아래</Button>
                     </div>
         </Container>
     )

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -22,7 +22,8 @@ export type MemberPropsType={
 
 export type AddPropsType = {
     addMember: (member:string,e:React.FormEvent)=>void,
-    toggleAdd:()=>void
+    toggleAdd:()=>void,
+    add:boolean
 }
 
 export type CausePropsType = {


### PR DESCRIPTION
모임원을 삭제했을 때 상태 업데이트가 바로바로 이루어지지 않아
삭제했을 때 1모임원의 경고 및 지각 미활동 횟수가 2모임원에게 넘어지는 경우가 발생했던 걸 수정했음

그리고 모임원 추가 버튼을 눌렀을 때 input으로 포커스가 맞춰지지않아 클릭하기 귀찮았던걸 수정해줬음